### PR TITLE
Fixed line numbering, capitalization cod-tplatp_la30px-aaa101.xml

### DIFF
--- a/la30px-aaa101/cod-tplatp_la30px-aaa101.xml
+++ b/la30px-aaa101/cod-tplatp_la30px-aaa101.xml
@@ -58,13 +58,13 @@
         <head xml:id="la30px-aaa101-Hd1e104">Praeambulum</head>
         <p xml:id="la30px-aaa101-d1e106">
           <pb ed="#S" n="1"/>
-          <lb ed="#S" n="1"/>aqui se contienen tre<lb ed="#S" n="2"/>ynta 
-          <lb ed="#S" n="3"/>proposiciones muy juridicas: en
-          <lb ed="#S" n="4"/>las quales sumaria y succintamente se 
-          <lb ed="#S" n="5"/>tocan muchas cosas pertencientes al de<lb ed="#S" n="6"/>recho
-          <lb ed="#S" n="7"/>quae la yglesia y los principes chri<lb ed="#S" n="6"/>stianos 
+          <lb ed="#S" n="1"/>Aqui se contienen tre<lb ed="#S" n="2"/>ynta 
+          proposiciones muy juridicas: en
+          <lb ed="#S" n="3"/>las quales sumaria y succintamente se 
+          <lb ed="#S" n="4"/>tocan muchas cosas pertencientes al de<lb ed="#S" n="5"/>recho
+          quae la yglesia y los principes chri<lb ed="#S" n="6"/>stianos 
           tienen / o pueden tener sobre los 
-          infieles de qualquier especie quae sean.
+          <lb ed="#S" n="7"/>infieles de qualquier especie quae sean.
         </p>
         <p xml:id="la30px-aaa101-d1e128">
           <lb ed="#S" n="8"/>Mayormente se assigna el verdadero 


### PR DESCRIPTION
Lines improperly numbered, leading to mistaken display of image coordinates. Fixed.